### PR TITLE
Remove config_cyanogenmod flag as it is not needed

### DIFF
--- a/overlay/packages/apps/Trebuchet/res/values/config.xml
+++ b/overlay/packages/apps/Trebuchet/res/values/config.xml
@@ -1,5 +1,4 @@
 <resources>
     <bool name="config_largeHeap">true</bool>
-    <bool name="config_cyanogenmod">true</bool>
     <bool name="is_large_screen">true</bool>
 </resources>


### PR DESCRIPTION
Trebuchet now uses the com.cyanogenmod.android feature to detect CyanogenMod
rather than the config flag
